### PR TITLE
Low balance notifications

### DIFF
--- a/src/main/api/api_test.go
+++ b/src/main/api/api_test.go
@@ -165,6 +165,6 @@ func TestApiImpl_CheckBalance(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Len(t, response, 2)
-	assert.Equal(t, apimodel.BalanceData{Currency: "ZEUR", NextPurchaseAmount: 300.0, Balance: 100.0}, response[0])
-	assert.Equal(t, apimodel.BalanceData{Currency: "ZUSD", NextPurchaseAmount: 50.0, Balance: 20.0}, response[1])
+	assert.Contains(t, response, apimodel.BalanceData{Currency: "ZEUR", NextPurchaseAmount: 300.0, Balance: 100.0})
+	assert.Contains(t, response, apimodel.BalanceData{Currency: "ZUSD", NextPurchaseAmount: 50.0, Balance: 20.0})
 }

--- a/src/main/api/api_test.go
+++ b/src/main/api/api_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	apimodel "github.com/jackpf/kraken-scheduler/src/main/api/model"
 	"github.com/jackpf/kraken-scheduler/src/main/testutil"
 	"testing"
 
@@ -146,4 +147,24 @@ func TestApi_TransactionStatus_NotFound(t *testing.T) {
 
 	assert.EqualError(t, err, "transaction test-id could not be found in open or closed order history")
 	assert.Nil(t, result)
+}
+
+func TestApiImpl_CheckBalance(t *testing.T) {
+	krakenAPI := new(testutil.MockKrakenApi)
+	api := NewApi(configmodel.Config{[]configmodel.Schedule{}}, false, krakenAPI)
+
+	krakenAPI.On("Balance").Return(&krakenapi.BalanceResponse{
+		ZEUR: 100.0,
+		ZUSD: 20.0,
+	},
+		nil)
+
+	request := []apimodel.BalanceRequest{{Pair: "XXBTZEUR", Amount: 100.0}, {Pair: "XXBTZEUR", Amount: 200.0}, {Pair: "XTZUSD", Amount: 50.0}}
+
+	response, err := api.CheckBalance(request)
+
+	assert.NoError(t, err)
+	assert.Len(t, response, 2)
+	assert.Equal(t, apimodel.BalanceData{Currency: "ZEUR", NextPurchaseAmount: 300.0, Balance: 100.0}, response[0])
+	assert.Equal(t, apimodel.BalanceData{Currency: "ZUSD", NextPurchaseAmount: 50.0, Balance: 20.0}, response[1])
 }

--- a/src/main/api/kraken_api_interface.go
+++ b/src/main/api/kraken_api_interface.go
@@ -7,4 +7,5 @@ type KrakenApiInterface interface {
 	AddOrder(pair string, direction string, orderType string, volume string, args map[string]string) (*krakenapi.AddOrderResponse, error)
 	OpenOrders(args map[string]string) (*krakenapi.OpenOrdersResponse, error)
 	ClosedOrders(args map[string]string) (*krakenapi.ClosedOrdersResponse, error)
+	Balance() (*krakenapi.BalanceResponse, error)
 }

--- a/src/main/api/model/balance_data.go
+++ b/src/main/api/model/balance_data.go
@@ -1,0 +1,18 @@
+package model
+
+import "fmt"
+
+type BalanceRequest struct {
+	Pair   string
+	Amount float64
+}
+
+func (r BalanceRequest) Currency() string {
+	return fmt.Sprintf("Z%s", r.Pair[len(r.Pair)-3:])
+}
+
+type BalanceData struct {
+	Currency           string
+	NextPurchaseAmount float64
+	Balance            float64
+}

--- a/src/main/api/model/balance_data.go
+++ b/src/main/api/model/balance_data.go
@@ -8,7 +8,7 @@ type BalanceRequest struct {
 }
 
 func (r BalanceRequest) Currency() string {
-	return fmt.Sprintf("Z%s", r.Pair[len(r.Pair)-3:])
+	return fmt.Sprintf("%s", r.Pair[len(r.Pair)-4:])
 }
 
 type BalanceData struct {

--- a/src/main/api/model/balance_data_test.go
+++ b/src/main/api/model/balance_data_test.go
@@ -1,0 +1,12 @@
+package model
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestBalanceRequest_Currency(t *testing.T) {
+	balanceRequest := BalanceRequest{Pair: "XXBTZEUR", Amount: 123.0}
+
+	assert.Equal(t, "ZEUR", balanceRequest.Currency())
+}

--- a/src/main/notifications/low_balance_notification.go
+++ b/src/main/notifications/low_balance_notification.go
@@ -1,0 +1,32 @@
+package notifications
+
+import (
+	"fmt"
+)
+
+func NewLowBalanceNotification(currency string, fiatAmount float64, balanceAmount float64) Notification {
+	return LowBalanceNotification{currency: currency, fiatAmount: fiatAmount, balanceAmount: balanceAmount}
+}
+
+type LowBalanceNotification struct {
+	currency      string
+	fiatAmount    float64
+	balanceAmount float64
+}
+
+func (n LowBalanceNotification) Subject() string {
+	return fmt.Sprintf("kraken-scheduler: low balance for %s", n.currency)
+}
+
+func (n LowBalanceNotification) Body() string {
+	return fmt.Sprintf(`Your balance is running low - purchases may start failing soon.
+
+You have %f %s in your account, and the next order amount is %f.
+
+Top up your account balance ASAP.`,
+		n.balanceAmount,
+		n.currency,
+		n.fiatAmount,
+	)
+
+}

--- a/src/main/scheduler/model/task_data.go
+++ b/src/main/scheduler/model/task_data.go
@@ -1,11 +1,31 @@
 package model
 
 import (
+	"github.com/go-co-op/gocron"
+	apimodel "github.com/jackpf/kraken-scheduler/src/main/api/model"
 	configmodel "github.com/jackpf/kraken-scheduler/src/main/config/model"
 )
 
 type TaskData struct {
+	Jobs []struct {
+		configmodel.Schedule
+		*gocron.Job
+	}
 	Schedule       configmodel.Schedule
 	Order          Order
 	TransactionIds []string
+	BalanceData    []apimodel.BalanceData
+}
+
+func (d TaskData) Job() *struct {
+	configmodel.Schedule
+	*gocron.Job
+} {
+	for _, job := range d.Jobs {
+		if job.Schedule == d.Schedule {
+			return &job
+		}
+	}
+
+	return nil
 }

--- a/src/main/scheduler/tasks/check_balance_task.go
+++ b/src/main/scheduler/tasks/check_balance_task.go
@@ -1,0 +1,54 @@
+package tasks
+
+import (
+	"github.com/jackpf/kraken-scheduler/src/main/api"
+	apimodel "github.com/jackpf/kraken-scheduler/src/main/api/model"
+	"github.com/jackpf/kraken-scheduler/src/main/notifications"
+	"github.com/jackpf/kraken-scheduler/src/main/scheduler/model"
+	log "github.com/sirupsen/logrus"
+)
+
+const alertThreshold = 1.5
+
+func NewCheckBalanceTask(api api.Api) CheckBalanceTask {
+	return CheckBalanceTask{api: api}
+}
+
+type CheckBalanceTask struct {
+	api api.Api
+}
+
+func (t CheckBalanceTask) Run(taskData *model.TaskData) error {
+	var requests []apimodel.BalanceRequest
+
+	for _, job := range taskData.Jobs {
+		requests = append(requests, apimodel.BalanceRequest{Pair: job.Pair, Amount: job.Amount})
+	}
+
+	balanceInfo, err := t.api.CheckBalance(requests)
+	if err != nil {
+		return err
+	}
+
+	taskData.BalanceData = balanceInfo
+
+	return nil
+}
+
+func (t CheckBalanceTask) Notifications(taskData model.TaskData) ([]notifications.Notification, []error) {
+	var balanceNotifications []notifications.Notification
+
+	for _, balance := range taskData.BalanceData {
+		if balance.Balance/balance.NextPurchaseAmount < alertThreshold {
+			log.Warnf("Low balance on account for %s", balance.Currency)
+
+			balanceNotifications = append(balanceNotifications, notifications.NewLowBalanceNotification(
+				balance.Currency,
+				balance.NextPurchaseAmount,
+				balance.Balance,
+			))
+		}
+	}
+
+	return balanceNotifications, nil
+}

--- a/src/main/scheduler/tasks/check_balance_task_test.go
+++ b/src/main/scheduler/tasks/check_balance_task_test.go
@@ -1,0 +1,51 @@
+package tasks
+
+import (
+	"github.com/go-co-op/gocron"
+	apimodel "github.com/jackpf/kraken-scheduler/src/main/api/model"
+	configmodel "github.com/jackpf/kraken-scheduler/src/main/config/model"
+	"github.com/jackpf/kraken-scheduler/src/main/notifications"
+	"github.com/jackpf/kraken-scheduler/src/main/scheduler/model"
+	"github.com/jackpf/kraken-scheduler/src/main/testutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckBalanceTask_Run(t *testing.T) {
+	api := new(testutil.MockApi)
+	task := NewCheckBalanceTask(api)
+	schedule := configmodel.Schedule{Cron: "***", Amount: 123.0, Pair: "XXBTZEUR"}
+	jobs := []struct {
+		configmodel.Schedule
+		*gocron.Job
+	}{{schedule, nil}}
+	taskData := model.TaskData{Jobs: jobs, Schedule: schedule}
+
+	balanceInfo := []apimodel.BalanceData{{Currency: "ZEUR", NextPurchaseAmount: 123.0, Balance: 456.0}}
+
+	api.On("CheckBalance", []apimodel.BalanceRequest{{Pair: "XXBTZEUR", Amount: 123.0}}).Return(balanceInfo, nil)
+
+	err := task.Run(&taskData)
+
+	assert.NoError(t, err)
+	assert.Equal(t, balanceInfo, taskData.BalanceData)
+}
+
+func TestCheckBalanceTask_Notifications(t *testing.T) {
+	api := new(testutil.MockApi)
+	task := NewCheckBalanceTask(api)
+	taskData := model.TaskData{BalanceData: []apimodel.BalanceData{
+		{Currency: "ZUSD", NextPurchaseAmount: 100.0, Balance: 150.0},
+		{Currency: "ZEUR", NextPurchaseAmount: 100.0, Balance: 149.99},
+	}}
+
+	balanceNotifications, errs := task.Notifications(taskData)
+
+	for _, err := range errs {
+		assert.NoError(t, err)
+	}
+
+	assert.Len(t, balanceNotifications, 1)
+	assert.Equal(t, notifications.NewLowBalanceNotification("ZEUR", 100.0, 149.99), balanceNotifications[0])
+}

--- a/src/main/scheduler/tasks/log_next_purchase_task.go
+++ b/src/main/scheduler/tasks/log_next_purchase_task.go
@@ -1,0 +1,26 @@
+package tasks
+
+import (
+	"github.com/jackpf/kraken-scheduler/src/main/notifications"
+	"github.com/jackpf/kraken-scheduler/src/main/scheduler/model"
+	log "github.com/sirupsen/logrus"
+)
+
+func NewLogNextPurchaseTask() LogNextPurchaseTask {
+	return LogNextPurchaseTask{}
+}
+
+type LogNextPurchaseTask struct {
+}
+
+func (t LogNextPurchaseTask) Run(taskData *model.TaskData) error {
+	if taskData.Job() != nil {
+		log.Infof("Next purchase for %s will occur at %+v", taskData.Job().Pair, taskData.Job().NextRun())
+	}
+
+	return nil
+}
+
+func (t LogNextPurchaseTask) Notifications(taskData model.TaskData) ([]notifications.Notification, []error) {
+	return nil, nil
+}

--- a/src/main/testutil/mock_api.go
+++ b/src/main/testutil/mock_api.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	krakenapi "github.com/beldur/kraken-go-api-client"
+	apimodel "github.com/jackpf/kraken-scheduler/src/main/api/model"
 	"github.com/jackpf/kraken-scheduler/src/main/scheduler/model"
 	"github.com/stretchr/testify/mock"
 )
@@ -28,6 +29,11 @@ func (m *MockApi) SubmitOrder(order model.Order) ([]string, error) {
 func (m *MockApi) TransactionStatus(transactionId string) (*krakenapi.Order, error) {
 	argsCalled := m.Called(transactionId)
 	return argsCalled.Get(0).(*krakenapi.Order), argsCalled.Error(1)
+}
+
+func (m *MockApi) CheckBalance(balanceRequests []apimodel.BalanceRequest) ([]apimodel.BalanceData, error) {
+	argsCalled := m.Called(balanceRequests)
+	return argsCalled.Get(0).([]apimodel.BalanceData), argsCalled.Error(1)
 }
 
 func (m *MockApi) IsLive() bool {

--- a/src/main/testutil/mock_kraken_api.go
+++ b/src/main/testutil/mock_kraken_api.go
@@ -28,3 +28,8 @@ func (m *MockKrakenApi) ClosedOrders(args map[string]string) (*krakenapi.ClosedO
 	argsCalled := m.Called(args)
 	return argsCalled.Get(0).(*krakenapi.ClosedOrdersResponse), argsCalled.Error(1)
 }
+
+func (m *MockKrakenApi) Balance() (*krakenapi.BalanceResponse, error) {
+	argsCalled := m.Called()
+	return argsCalled.Get(0).(*krakenapi.BalanceResponse), argsCalled.Error(1)
+}


### PR DESCRIPTION
Fixes: https://github.com/jackpf/kraken-scheduler/issues/12

Adds a task to send email alerts when the account balance for a given currency is < 1.5 * the next order amount.

Also adds the "log next purchase" task, to remove this from the scheduler.