### PR TITLE
Increase retry delay to 60 seconds

### DIFF
--- a/src/main/main.go
+++ b/src/main/main.go
@@ -55,7 +55,7 @@ func main() {
 	apiInstance := api.NewApi(*appConfig, args.IsLive, args.IsVerbose, krakenAPI)
 	schedulerInstance := scheduler.NewScheduler(*appConfig, metrics.NewMetrics(), apiInstance, notifiers)
 
-	retry.DefaultAttempts = 10
+	retry.DefaultAttempts = 11
 	retry.DefaultDelay = 60 * time.Second
 	retry.DefaultDelayType = retry.BackOffDelay
 	retry.DefaultOnRetry = func(n uint, err error) {

--- a/src/main/main.go
+++ b/src/main/main.go
@@ -56,7 +56,7 @@ func main() {
 	schedulerInstance := scheduler.NewScheduler(*appConfig, metrics.NewMetrics(), apiInstance, notifiers)
 
 	retry.DefaultAttempts = 10
-	retry.DefaultDelay = 1 * time.Second
+	retry.DefaultDelay = 60 * time.Second
 	retry.DefaultDelayType = retry.BackOffDelay
 	retry.DefaultOnRetry = func(n uint, err error) {
 		log.Warnf("Retryable call failed (attempt %d): %s", n+1, err.Error())

--- a/src/main/main.go
+++ b/src/main/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"github.com/avast/retry-go"
 	"github.com/jackpf/kraken-scheduler/src/main/api"
 	"github.com/jackpf/kraken-scheduler/src/main/config"
@@ -59,7 +60,11 @@ func main() {
 	retry.DefaultDelay = 60 * time.Second
 	retry.DefaultDelayType = retry.BackOffDelay
 	retry.DefaultOnRetry = func(n uint, err error) {
-		log.Warnf("Retryable call failed (attempt %d): %s", n+1, err.Error())
+		subject := fmt.Sprintf("Retryable call failed (attempt %d)", n+1)
+		log.Warnf("%s: %s", subject, err.Error())
+		for _, n := range notifiers {
+			_ = (*n).Send(subject, err.Error())
+		}
 	}
 
 	go metrics.Start()

--- a/src/main/metrics/metrics.go
+++ b/src/main/metrics/metrics.go
@@ -48,6 +48,10 @@ func NewMetrics() Metrics {
 			Name: "kraken_scheduler_errors_total",
 			Help: "The total number of errors during purchase process",
 		}),
+		retriesCounter: promauto.NewCounter(prometheus.CounterOpts{
+			Name: "kraken_scheduler_errors_total",
+			Help: "The total number of errors during purchase process",
+		}),
 	}
 }
 
@@ -56,6 +60,7 @@ type Metrics interface {
 	LogPurchase(pair model.Pair, amount float64, fiatAmount float64, holdings float64, holdingsValue float64)
 	LogCurrencyBalance(asset model.Asset, holdings float64)
 	LogError()
+	LogRetry()
 }
 
 type MetricsImpl struct {
@@ -69,6 +74,7 @@ type MetricsImpl struct {
 	assetBalanceValueGauge       *prometheus.GaugeVec
 	currencyBalanceAmountGauge   *prometheus.GaugeVec
 	errorsCounter                prometheus.Counter
+	retriesCounter               prometheus.Counter
 }
 
 func (m *MetricsImpl) LogOrder(pair model.Pair) {
@@ -91,4 +97,8 @@ func (m *MetricsImpl) LogCurrencyBalance(asset model.Asset, holdings float64) {
 
 func (m *MetricsImpl) LogError() {
 	m.errorsCounter.Inc()
+}
+
+func (m *MetricsImpl) LogRetry() {
+	m.retriesCounter.Inc()
 }

--- a/src/main/testutil/mock_metrics.go
+++ b/src/main/testutil/mock_metrics.go
@@ -24,3 +24,7 @@ func (m *MockMetrics) LogCurrencyBalance(asset model.Asset, holdings float64) {
 func (m *MockMetrics) LogError() {
 	m.Called()
 }
+
+func (m *MockMetrics) LogRetry() {
+	m.Called()
+}


### PR DESCRIPTION
Recent failures due to "market in post only mode".
Increasing default retry time to 60s, meaning the 10th exponential retry will be after 68.25 hours.

Hopefully should be enough to catch most failures.